### PR TITLE
Add test coverage for the empty recommender

### DIFF
--- a/tests/test_emptyrecommender.py
+++ b/tests/test_emptyrecommender.py
@@ -1,0 +1,16 @@
+from taar.recommenders.empty_recommender import EmptyRecommender
+
+
+def test_can_recommend():
+    # Tests that the empty recommender can always recommend.
+    r = EmptyRecommender()
+    assert r.can_recommend({})
+
+
+def test_empty_recommendations():
+    # Tests that the empty recommender always recommends an empty list
+    # of addons.
+    r = EmptyRecommender()
+    recommendations = r.recommend({}, 1)
+    assert isinstance(recommendations, list)
+    assert len(recommendations) == 0


### PR DESCRIPTION
This adds test coverage for the no recommendation (empty) recommender.