### PR TITLE
Make the collaborative filtering class return addon ids

### DIFF
--- a/taar/recommenders/collaborative_recommender.py
+++ b/taar/recommenders/collaborative_recommender.py
@@ -82,13 +82,15 @@ class CollaborativeRecommender:
         for addon in self.raw_item_matrix:
             # We don't really need to show the items we requested. They will always
             # end up with the greatest score.
-            if addon.get("id") in installed_addons:
+            hashed_id = str(addon.get("id"))
+            if (hashed_id in installed_addons or
+                hashed_id not in self.addon_mapping):
                 continue
 
             dist = np.dot(user_factors_transposed, addon.get('features'))
-            # TODO: The next function should read the addon ids from the "addon_mapping"
-            # looking them up by 'id' (which is an hashed value).
-            addon_id = str(addon.get('id'))  # self.addon_mapping[str(addon.get('id'))]
+            # Read the addon ids from the "addon_mapping" looking it
+            # up by 'id' (which is an hashed value).
+            addon_id = self.addon_mapping[hashed_id].get("id")
             distances[addon_id] = dist
 
         # Sort the suggested addons by their score and return the sorted list of addon

--- a/tests/test_collaborativerecommender.py
+++ b/tests/test_collaborativerecommender.py
@@ -5,9 +5,9 @@ from taar.recommenders.collaborative_recommender import CollaborativeRecommender
 
 
 FAKE_MAPPING = {
-    "1234": "Nice addon name",
-    "4567": "Better than the previous one",
-    "7890": "Super"
+    "1234": {"id": "some-id@nice", "name": "Nice addon name"},
+    "4567": {"id": "some-other@id", "name": "Better than the previous one"},
+    "7890": {"id": "8bae1075-f34e-451a-8053-9a7aacfd5af9", "name": "Super"}
 }
 FAKE_ADDON_MATRIX = [
     {"id": "1234", "features": [1.0, 0.0, 0.0]},
@@ -62,5 +62,7 @@ def test_recommendations(activate_responses):
     assert isinstance(recommendations, list)
     assert len(recommendations) == 1
 
-
-# TODO: add test coverage for errors fetching HTTP files.
+    # We are not sure about what addon will be recommended in the test.
+    # Only make sure the reported id is among the expected ones.
+    ADDON_IDS = [value['id'] for value in FAKE_MAPPING.values()]
+    assert recommendations[0] in ADDON_IDS


### PR DESCRIPTION
This changes the CollaborativeRecommender to use the new
addon mapping JSON file format and return addon ids instead
of the hacky hashed ids/names.